### PR TITLE
suggested fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM rocker/tidyverse
 
-# Install necessary packages 
-RUN Rscript -e "install.packages('grDevices')"
-RUN Rscript -e "install.packages('readxl')"
-RUN Rscript -e "install.packages('lubridate')"
-RUN Rscript -e "install.packages('here')"
-
 # make a project directory in the container
 # we will mount our local project directory to this directory
 RUN mkdir /project
@@ -16,8 +10,11 @@ COPY ./ /project/
 # set working directory
 WORKDIR /project
 
-# make R scripts executable
-RUN chmod +x /project/R/*.R
+# Install necessary packages 
+RUN Rscript -e "install.packages('grDevices')"
+RUN Rscript -e "install.packages('readxl')"
+RUN Rscript -e "install.packages('lubridate')"
+RUN Rscript -e "install.packages('here')"
 
 # make container entry point report creation
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ COPY ./ /project/
 WORKDIR /project
 
 # Install necessary packages 
-RUN Rscript -e "install.packages('grDevices')"
-RUN Rscript -e "install.packages('readxl')"
-RUN Rscript -e "install.packages('lubridate')"
-RUN Rscript -e "install.packages('here')"
+# RUN Rscript -e "install.packages('grDevices')"
+# RUN Rscript -e "install.packages('readxl')"
+# RUN Rscript -e "install.packages('lubridate')"
+# RUN Rscript -e "install.packages('here')"
+RUN Rscript -e "renv::restore()"
 
 # make container entry point report creation
 CMD /bin/bash


### PR DESCRIPTION
This PR moves your package installations to occur in the project directory, so that renv registers the installations.

The container builds and seems to execute, though the implementation is still suboptimal -- renv::restore() is called at run time (rather than build time) so when the container runs, it still goes through a lengthy install process.